### PR TITLE
Add support for custom components in chatbot

### DIFF
--- a/components/chatbot/chatbot.tsx
+++ b/components/chatbot/chatbot.tsx
@@ -1,79 +1,144 @@
-"use client"
+"use client";
 
-import Chatbot from "@/registry/chatbot"
-import { useState } from "react"
+import Chatbot from "@/registry/chatbot";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
-export default function ChatbotDemo(){
-    const [state,setState] = useState<any>()
-    return (
-        <Chatbot config={{
-            name: "Chatbot",
-            image: "https://shadfinity.sanjaybora.in/images/chatbot.png",
-            initialStep: 'start',
-            tooltip: 'Hello',
-            flow: {
-                start: {
-                    delay: 500,
-                    message: 'Hi, How may I help you?',
-                    options: ['What can you do?','Form example'],
-                    inputboxDisabled:true,
-                    next:(value:any)=>{
-                        if(value=="What can you do?"){
-                            return "what_can_you_do"
-                        }
-                        else if(value=="Form example"){
-                            return "form_start"
-                        }
-                        else{
-                            return "start"
-                        }
-                    }
-                },
-                what_can_you_do:{
-                    delay:500,
-                    message: "I can do anything",
-                    autoNext:true,
-                    next: 'start'
-                },
-                //form
-                form_start:{
-                    delay:500,
-                    message:"What is your name?",
-                    validation: (value:any)=>{
-                        if(value.length<3){
-                            return "⚠️ Name must be atleast three characters long"
-                        }else{
-                            setState((prev:any)=>({...prev,name:value}))
-                            return true
-                        }
-                    },
-                    next: "ask_age"
-                },
-                ask_age:{
-                    delay:500,
-                    message: "What is your age?",
-                    validation: (value:any)=>{
-                        if(isNaN(value)){
-                            return "⚠️ Age must be numeric"
-                        }else if(value<1||value>100){
-                            return "⚠️ Age can't be less than 1 or more than 100"
-                        }else{
-                            setState((prev:any)=>({...prev,age:value}))
-                            return true
-                        }
-                    },
-                    next: 'form_finish'
-                },
-                form_finish:{
-                    delay:500,
-                    message: `Thank you ${state?.name} for your response.\n Your age - ${state?.age} has been recorded`,
-                    autoNext:true,
-                    next: ()=>{
-                        window.alert(`Name:${state?.name}\nAge:${state?.age}`)
-                        return 'start'
-                    }
-                }
-            }
-        }} />
-    )
+export default function ChatbotDemo() {
+  const [state, setState] = useState<any>();
+
+  const customMessage = (
+    <div className="flex flex-col gap-2">
+      <p>Here&apos;s a custom message with components:</p>
+      <Card className="p-2">
+        <p>This is a card component</p>
+        <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          And this is a badge
+        </span>
+      </Card>
+    </div>
+  );
+
+  const customOptions = [
+    "Regular option",
+    <div key="badge-option" className="flex items-center gap-2">
+      <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        New
+      </span>
+      <span>Option with badge</span>
+    </div>,
+    <div key="button-option" className="flex items-center gap-2">
+      <Button size="sm">Click me</Button>
+      <span>Option with button</span>
+    </div>,
+  ];
+
+  return (
+    <Chatbot
+      config={{
+        name: "Chatbot",
+        image: "https://shadfinity.sanjaybora.in/images/chatbot.png",
+        initialStep: "start",
+        tooltip: "Hello",
+        flow: {
+          start: {
+            delay: 500,
+            message: "Hi, How may I help you?",
+            options: ["What can you do?", "Form example", "Custom components"],
+            inputboxDisabled: true,
+            next: (value: any) => {
+              if (value == "What can you do?") {
+                return "what_can_you_do";
+              } else if (value == "Form example") {
+                return "form_start";
+              } else if (value == "Custom components") {
+                return "custom_components";
+              } else {
+                return "start";
+              }
+            },
+          },
+          what_can_you_do: {
+            delay: 500,
+            message: "I can do anything",
+            autoNext: true,
+            next: "start",
+          },
+          custom_components: {
+            delay: 500,
+            message: customMessage,
+            options: customOptions,
+            inputboxDisabled: true,
+            next: (value: any) => {
+              if (value === "Regular option") {
+                return "regular_option_response";
+              } else if (value === "option-1") {
+                return "badge_option_response";
+              } else if (value === "option-2") {
+                return "button_option_response";
+              }
+              return "start";
+            },
+          },
+          regular_option_response: {
+            delay: 500,
+            message: "You selected the regular option",
+            autoNext: true,
+            next: "start",
+          },
+          badge_option_response: {
+            delay: 500,
+            message: "You selected the option with badge",
+            autoNext: true,
+            next: "start",
+          },
+          button_option_response: {
+            delay: 500,
+            message: "You selected the option with button",
+            autoNext: true,
+            next: "start",
+          },
+          //form
+          form_start: {
+            delay: 500,
+            message: "What is your name?",
+            validation: (value: any) => {
+              if (value.length < 3) {
+                return "⚠️ Name must be atleast three characters long";
+              } else {
+                setState((prev: any) => ({ ...prev, name: value }));
+                return true;
+              }
+            },
+            next: "ask_age",
+          },
+          ask_age: {
+            delay: 500,
+            message: "What is your age?",
+            validation: (value: any) => {
+              if (isNaN(value)) {
+                return "⚠️ Age must be numeric";
+              } else if (value < 1 || value > 100) {
+                return "⚠️ Age can't be less than 1 or more than 100";
+              } else {
+                setState((prev: any) => ({ ...prev, age: value }));
+                return true;
+              }
+            },
+            next: "form_finish",
+          },
+          form_finish: {
+            delay: 500,
+            message: `Thank you ${state?.name} for your response.\n Your age - ${state?.age} has been recorded`,
+            autoNext: true,
+            next: () => {
+              window.alert(`Name:${state?.name}\nAge:${state?.age}`);
+              return "start";
+            },
+          },
+        },
+      }}
+    />
+  );
 }

--- a/components/chatbot/chatbot.tsx
+++ b/components/chatbot/chatbot.tsx
@@ -45,7 +45,12 @@ export default function ChatbotDemo() {
           start: {
             delay: 500,
             message: "Hi, How may I help you?",
-            options: ["What can you do?", "Form example", "Custom components"],
+            options: [
+              "What can you do?",
+              "Form example",
+              "Custom components",
+              "Multiple choice demo",
+            ],
             inputboxDisabled: true,
             next: (value: any) => {
               if (value == "What can you do?") {
@@ -54,6 +59,8 @@ export default function ChatbotDemo() {
                 return "form_start";
               } else if (value == "Custom components") {
                 return "custom_components";
+              } else if (value == "Multiple choice demo") {
+                return "multiple_choice_demo";
               } else {
                 return "start";
               }
@@ -80,6 +87,36 @@ export default function ChatbotDemo() {
               }
               return "start";
             },
+          },
+          multiple_choice_demo: {
+            delay: 500,
+            message: "Select your interests (choose 2-3):",
+            multipleChoice: {
+              options: [
+                "Web Development",
+                "Mobile Development",
+                "UI/UX Design",
+                "Backend Development",
+                "DevOps",
+                "Machine Learning",
+              ],
+              min: 2,
+              max: 3,
+              submitText: "Continue",
+            },
+            next: (values: string[]) => {
+              setState((prev: { interests?: string[] }) => ({
+                ...prev,
+                interests: values,
+              }));
+              return "multiple_choice_response";
+            },
+          },
+          multiple_choice_response: {
+            delay: 500,
+            message: `You selected: ${state?.interests?.join(", ")}`,
+            autoNext: true,
+            next: "start",
           },
           regular_option_response: {
             delay: 500,

--- a/registry/chatbot.tsx
+++ b/registry/chatbot.tsx
@@ -1,266 +1,370 @@
-"use client"
+"use client";
 import { RefreshCcw, Send, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
 type flowNode = {
-    message?: string,
-    options?: string[],
-    inputboxDisabled?: boolean,
-    validation?: ((value: any) => Promise<boolean | string> | boolean | string)
-    next?: string | ((value: any) => string),
-    delay?: number,
-    autoNext?: boolean
-}
+  message?: string | React.ReactNode;
+  options?: string[] | React.ReactNode[];
+  inputboxDisabled?: boolean;
+  validation?: (value: any) => Promise<boolean | string> | boolean | string;
+  next?: string | ((value: any) => string);
+  delay?: number;
+  autoNext?: boolean;
+};
 
 export type configType = {
-    name: string,
-    image?: string,
-    initialStep: string,
-    tooltip?: string,
-    defaultOpen?: {
-        open: boolean,
-        delay?: number
-    },
-    flow: {
-        [key: string]: flowNode
-    }
-}
+  name: string;
+  image?: string;
+  initialStep: string;
+  tooltip?: string;
+  defaultOpen?: {
+    open: boolean;
+    delay?: number;
+  };
+  flow: {
+    [key: string]: flowNode;
+  };
+};
 
 function Loader({ image }: { image: string }) {
-    return (
-        <div className="my-2 flex gap-2">
-            <img src={image} className="bg-primary text-primary-foreground rounded-full w-10 h-10 flex-none border border-primary" />
-            <div className="p-2 bg-secondary rounded-lg flex items-center gap-1">
-                <div className="w-2 h-2 rounded-lg bg-primary animate-bounce"></div>
-                <div className="w-2 h-2 rounded-lg bg-primary animate-bounce delay-100"></div>
-                <div className="w-2 h-2 rounded-lg bg-primary animate-bounce delay-200"></div>
-            </div>
-        </div>
-    )
+  return (
+    <div className="my-2 flex gap-2">
+      <img
+        src={image}
+        className="bg-primary text-primary-foreground rounded-full w-10 h-10 flex-none border border-primary"
+      />
+      <div className="p-2 bg-secondary rounded-lg flex items-center gap-1">
+        <div className="w-2 h-2 rounded-lg bg-primary animate-bounce"></div>
+        <div className="w-2 h-2 rounded-lg bg-primary animate-bounce delay-100"></div>
+        <div className="w-2 h-2 rounded-lg bg-primary animate-bounce delay-200"></div>
+      </div>
+    </div>
+  );
 }
 
 function UserMessage({ msg }: { msg: any }) {
-    return (
-        <div className="flex justify-end my-2">
-            <div className="bg-primary text-primary-foreground p-2 rounded-lg whitespace-pre-line">
-                {msg}
-            </div>
-        </div>
-    )
+  return (
+    <div className="flex justify-end my-2">
+      <div className="bg-primary text-primary-foreground p-2 rounded-lg whitespace-pre-line">
+        {msg}
+      </div>
+    </div>
+  );
 }
 
-function Message({ message, image }: { message: any, image: string }) {
-    return (
-        <div className="flex gap-2 my-2">
-            <img src={image} className="bg-primary text-primary-foreground rounded-full w-10 h-10 flex-none border border-primary" />
-            <div>
-                <div className="p-2 bg-secondary rounded-lg rounded-b-none whitespace-break-spaces break-all">{message}</div>
-            </div>
+function Message({ message, image }: { message: any; image: string }) {
+  return (
+    <div className="flex gap-2 my-2">
+      <img
+        src={image}
+        className="bg-primary text-primary-foreground rounded-full w-10 h-10 flex-none border border-primary"
+      />
+      <div>
+        <div className="p-2 bg-secondary rounded-lg rounded-b-none whitespace-break-spaces break-all">
+          {typeof message === "string" ? message : message}
         </div>
-    )
+      </div>
+    </div>
+  );
 }
 
-function SingleChoice({ items, onClick }: { items: string[], onClick: any }) {
-    const [formopen, setFormOpen] = useState(true)
-    const [val, setVal] = useState('')
-    return (
-        <>
-            <div className="flex flex-col gap-2">
-                {
-                    formopen && <div className="grid grid-cols-2 gap-3">
-                        {
-                            items.map((item, index) => {
-                                return (
-                                    <div key={index} onClick={() => {
-                                        if (val == '') {
-                                            onClick(item);
-                                            setVal(item)
-                                        }
-                                    }} className="w-full">
-                                        <Button className="flex w-full h-full flex-col py-2 px-2 hover:shadow-md text-wrap" variant={val == item ? 'default' : "outline"}>
-                                            {item}
-                                        </Button>
-                                    </div>
-                                )
-                            })
-                        }
-                    </div>
-                }
-            </div>
-        </>
-    )
+function SingleChoice({
+  items,
+  onClick,
+}: {
+  items: (string | React.ReactNode)[];
+  onClick: any;
+}) {
+  const [formopen, setFormOpen] = useState(true);
+  const [val, setVal] = useState("");
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {formopen && (
+          <div className="grid grid-cols-2 gap-3">
+            {items.map((item, index) => {
+              const itemValue =
+                typeof item === "string" ? item : `option-${index}`;
+              return (
+                <div
+                  key={index}
+                  onClick={() => {
+                    if (val == "") {
+                      onClick(itemValue);
+                      setVal(itemValue);
+                    }
+                  }}
+                  className="w-full"
+                >
+                  <Button
+                    className="flex w-full h-full flex-col py-2 px-2 hover:shadow-md text-wrap"
+                    variant={val == itemValue ? "default" : "outline"}
+                  >
+                    {item}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </>
+  );
 }
 
 export default function Chatbot({ config }: { config: configType }) {
-    const configRef = useRef<configType>(config)
-    const scrollViewportRef = useRef<any>(null)
-    const inputRef = useRef<any>(null)
-    const [open, setOpen] = useState(false)
-    const [messages, setMessages] = useState<any>([])
-    const [input, setInput] = useState('')
-    const [currentStep, setCurrentStep] = useState<string>(configRef.current.initialStep)
+  const configRef = useRef<configType>(config);
+  const scrollViewportRef = useRef<any>(null);
+  const inputRef = useRef<any>(null);
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<any>([]);
+  const [input, setInput] = useState("");
+  const [currentStep, setCurrentStep] = useState<string>(
+    configRef.current.initialStep
+  );
 
-    async function validate(val: any, _step: string) {
-        const step = configRef.current.flow[_step]
-        const v = await step.validation?.(val)
-        if (v == true) {
-            return true
-        } else if (v == false) {
-            setMessages((prev: any) => ([...prev, <Message image={configRef.current.image!} message={'⚠️Invalid Input!! Try again'} key={prev.length} />]))
-            return false
-        } else {
-            setMessages((prev: any) => ([...prev, <Message image={configRef.current.image!} message={v} key={prev.length} />]))
-            return false
-        }
+  async function validate(val: any, _step: string) {
+    const step = configRef.current.flow[_step];
+    const v = await step.validation?.(val);
+    if (v == true) {
+      return true;
+    } else if (v == false) {
+      setMessages((prev: any) => [
+        ...prev,
+        <Message
+          image={configRef.current.image!}
+          message={"⚠️Invalid Input!! Try again"}
+          key={prev.length}
+        />,
+      ]);
+      return false;
+    } else {
+      setMessages((prev: any) => [
+        ...prev,
+        <Message
+          image={configRef.current.image!}
+          message={v}
+          key={prev.length}
+        />,
+      ]);
+      return false;
+    }
+  }
+
+  async function onInput(val: any, _step: string) {
+    const step = configRef.current.flow[_step];
+    // validation
+    if (step.validation) {
+      if ((await validate(val, _step)) != true) {
+        return;
+      }
     }
 
-    async function onInput(val: any, _step: string) {
-        const step = configRef.current.flow[_step]
-        // validation
-        if (step.validation) {
-            if (await validate(val, _step) != true) {
-                return
-            }
-        }
+    // get next step
+    const nextStep =
+      (typeof step.next === "function" ? step.next(val) : step.next) || "";
 
-        // get next step
-        const nextStep = (typeof step.next === 'function' ? step.next(val) : step.next) || ""
+    // update messages
+    setMessages((prev: any) => [
+      ...prev,
+      <UserMessage msg={val} key={prev.length} />,
+    ]);
+    addMessage(nextStep);
 
-        // update messages
-        setMessages((prev: any) => ([...prev, <UserMessage msg={val} key={prev.length} />]))
-        addMessage(nextStep)
+    // update states
+    setCurrentStep(nextStep);
+    setInput("");
+  }
 
-        // update states
-        setCurrentStep(nextStep)
-        setInput('')
+  function addMessage(_step: string) {
+    const step = configRef.current.flow[_step];
+
+    // set input disabled
+    if (step.inputboxDisabled) {
+      if (inputRef.current) inputRef.current.disabled = true;
+    } else {
+      if (inputRef.current) inputRef.current.disabled = false;
     }
 
-    function addMessage(_step: string) {
-        const step = configRef.current.flow[_step]
-
-        // set input disabled
-        if (step.inputboxDisabled) { if (inputRef.current) inputRef.current.disabled = true }
-        else { if (inputRef.current) inputRef.current.disabled = false }
-
-        // add message
-        setMessages((prev: any) => ([...prev, <Loader key={prev.length} image={configRef.current.image!} />]))
-        setTimeout(() => {
-            setMessages((prev: any) => {
-                const m = prev.slice(0, -1);
-                if (step.message) {
-                    m.push(<Message message={step.message} key={m.length} image={configRef.current.image!} />)
-                }
-                if (step.options) {
-                    m.push(<SingleChoice items={step.options!} onClick={(val: any) => onInput(val, _step)} key={m.length} />)
-                }
-                return [...m]
-            })
-
-            if (step.autoNext) {
-                const nextStep = (typeof step.next === 'function' ? step.next('') : step.next) || ''
-                setCurrentStep(nextStep);
-                addMessage(nextStep)
-            }
-        }, step.delay)
-    }
-
-    function reload() {
-        setMessages([])
-        addMessage(config.initialStep)
-    }
-
-    let isMounted = false;
-    useEffect(() => {
-        if (!isMounted) {
-            // default open state
-            if (configRef.current.defaultOpen?.open) {
-                setTimeout(() => setOpen(true), configRef.current.defaultOpen?.delay)
-            }
-            // add first message
-            addMessage(currentStep)
-            isMounted = true
+    // add message
+    setMessages((prev: any) => [
+      ...prev,
+      <Loader key={prev.length} image={configRef.current.image!} />,
+    ]);
+    setTimeout(() => {
+      setMessages((prev: any) => {
+        const m = prev.slice(0, -1);
+        if (step.message) {
+          m.push(
+            <Message
+              message={step.message}
+              key={m.length}
+              image={configRef.current.image!}
+            />
+          );
         }
-    }, [])
-
-    useEffect(() => { configRef.current = config }, [config])
-
-    // scroll to bottom whenever messages are updated
-    useEffect(() => {
-        const viewport = scrollViewportRef.current;
-        if (viewport) {
-            viewport.scrollTo({
-                top: viewport.scrollHeight,
-                behavior: "smooth", // Smooth scrolling effect
-            });
+        if (step.options) {
+          m.push(
+            <SingleChoice
+              items={step.options!}
+              onClick={(val: any) => onInput(val, _step)}
+              key={m.length}
+            />
+          );
         }
-    }, [messages])
-    return (
-        <div className="fixed z-50 bottom-5 right-5 sm:bottom-10 sm:right-10">
-            <div className="relative">
-                <button id="chatbot-trigger" className="flex items-center gap-4" onClick={() => setOpen(true)}>
-                    {configRef.current.tooltip &&
-                        <div className=" bg-background p-2 shadow border rounded-xl rounded-br-none max-w-64">{configRef.current.tooltip}</div>
-                    }
-                    <img src={configRef.current.image} className="w-16 h-16 object-cover rounded-full border border-primary" />
-                </button>
-                {open &&
-                    <Card className={cn("absolute right-0  bottom-0 h-[75vh] max-h-[600px] w-[calc(100vw-40px)] sm:w-96 rounded-xl p-3 flex flex-col duration-300", open && "animate-in zoom-in slide-in-from-bottom slide-in-from-right")}>
-                        <div className="bg-primary text-primary-foreground h-12 w-full rounded-xl flex justify-between p-2 px-3">
-                            <div className="flex gap-3 items-center">
-                                <img src={configRef.current.image} className="w-8 h-8 rounded-full" />
-                                {configRef.current.name}
-                            </div>
-                            <div className="flex gap-2">
-                                <button className="hover:bg-primary-foreground hover:text-primary rounded-lg duration-300 p-1"
-                                    onClick={() => reload()}
-                                >
-                                    <RefreshCcw />
-                                </button>
-                                <button className="hover:bg-primary-foreground hover:text-primary rounded-lg duration-300 p-1"
-                                    onClick={() => setOpen(false)}
-                                >
-                                    <X />
-                                </button>
-                            </div>
-                        </div>
-                         {/* Using scroll area directly from radix ui because it doesnt pass ref to viewport by default */}
-                        <ScrollAreaPrimitive.Root className="relative overflow-hidden flex-grow py-2 px-3 ">
-                            <ScrollAreaPrimitive.Viewport ref={scrollViewportRef} className="h-full w-full rounded-[inherit]">
-                                {messages.map((m: any, index: number) => <div key={index}>{m}</div>)}
-                            </ScrollAreaPrimitive.Viewport>
-                            <ScrollAreaPrimitive.Scrollbar />
-                            <ScrollAreaPrimitive.Corner />
-                        </ScrollAreaPrimitive.Root>
-                        <div className="w-full">
-                            <div className="flex">
-                                <Input type='text' ref={inputRef} className="h-12 rounded-r-none" value={input}
-                                    onChange={e => setInput(e.target.value)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter') {
-                                            e.preventDefault();
-                                            onInput(input, currentStep);
-                                        }
-                                    }}
-                                    placeholder="Type your answer..." />
-                                <Button className="h-12 rounded-l-none hover:bg-primary" onClick={() => onInput(input, currentStep)} disabled={inputRef?.current?.disabled}>
-                                    <Send />
-                                </Button>
-                            </div>
-                            <div className="flex items-center justify-center gap-2 text-sm mt-2">
-                                Built By
-                                <a href="https://shadfinity.sanjaybora.in" target="_blank" className="text-blue-600 hover:underline">
-                                    Shadfinity</a>
-                                <img src="https://shadfinity.sanjaybora.in/favicon.ico" className="w-4 h-4" />
-                            </div>
-                        </div>
-                    </Card>
-                }
+        return [...m];
+      });
+
+      if (step.autoNext) {
+        const nextStep =
+          (typeof step.next === "function" ? step.next("") : step.next) || "";
+        setCurrentStep(nextStep);
+        addMessage(nextStep);
+      }
+    }, step.delay);
+  }
+
+  function reload() {
+    setMessages([]);
+    addMessage(config.initialStep);
+  }
+
+  let isMounted = false;
+  useEffect(() => {
+    if (!isMounted) {
+      // default open state
+      if (configRef.current.defaultOpen?.open) {
+        setTimeout(() => setOpen(true), configRef.current.defaultOpen?.delay);
+      }
+      // add first message
+      addMessage(currentStep);
+      isMounted = true;
+    }
+  }, []);
+
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
+
+  // scroll to bottom whenever messages are updated
+  useEffect(() => {
+    const viewport = scrollViewportRef.current;
+    if (viewport) {
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior: "smooth", // Smooth scrolling effect
+      });
+    }
+  }, [messages]);
+  return (
+    <div className="fixed z-50 bottom-5 right-5 sm:bottom-10 sm:right-10">
+      <div className="relative">
+        <button
+          id="chatbot-trigger"
+          className="flex items-center gap-4"
+          onClick={() => setOpen(true)}
+        >
+          {configRef.current.tooltip && (
+            <div className=" bg-background p-2 shadow border rounded-xl rounded-br-none max-w-64">
+              {configRef.current.tooltip}
             </div>
-        </div>
-    )
+          )}
+          <img
+            src={configRef.current.image}
+            className="w-16 h-16 object-cover rounded-full border border-primary"
+          />
+        </button>
+        {open && (
+          <Card
+            className={cn(
+              "absolute right-0  bottom-0 h-[75vh] max-h-[600px] w-[calc(100vw-40px)] sm:w-96 rounded-xl p-3 flex flex-col duration-300",
+              open &&
+                "animate-in zoom-in slide-in-from-bottom slide-in-from-right"
+            )}
+          >
+            <div className="bg-primary text-primary-foreground h-12 w-full rounded-xl flex justify-between p-2 px-3">
+              <div className="flex gap-3 items-center">
+                <img
+                  src={configRef.current.image}
+                  className="w-8 h-8 rounded-full"
+                />
+                {configRef.current.name}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  className="hover:bg-primary-foreground hover:text-primary rounded-lg duration-300 p-1"
+                  onClick={() => reload()}
+                >
+                  <RefreshCcw />
+                </button>
+                <button
+                  className="hover:bg-primary-foreground hover:text-primary rounded-lg duration-300 p-1"
+                  onClick={() => setOpen(false)}
+                >
+                  <X />
+                </button>
+              </div>
+            </div>
+            {/* Using scroll area directly from radix ui because it doesnt pass ref to viewport by default */}
+            <ScrollAreaPrimitive.Root className="relative overflow-hidden flex-grow py-2 px-3 ">
+              <ScrollAreaPrimitive.Viewport
+                ref={scrollViewportRef}
+                className="h-full w-full rounded-[inherit]"
+              >
+                {messages.map((m: any, index: number) => (
+                  <div key={index}>{m}</div>
+                ))}
+              </ScrollAreaPrimitive.Viewport>
+              <ScrollAreaPrimitive.Scrollbar />
+              <ScrollAreaPrimitive.Corner />
+            </ScrollAreaPrimitive.Root>
+            <div className="w-full">
+              <div className="flex">
+                <Input
+                  type="text"
+                  ref={inputRef}
+                  className="h-12 rounded-r-none"
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      onInput(input, currentStep);
+                    }
+                  }}
+                  placeholder="Type your answer..."
+                />
+                <Button
+                  className="h-12 rounded-l-none hover:bg-primary"
+                  onClick={() => onInput(input, currentStep)}
+                  disabled={inputRef?.current?.disabled}
+                >
+                  <Send />
+                </Button>
+              </div>
+              <div className="flex items-center justify-center gap-2 text-sm mt-2">
+                Built By
+                <a
+                  href="https://shadfinity.sanjaybora.in"
+                  target="_blank"
+                  className="text-blue-600 hover:underline"
+                >
+                  Shadfinity
+                </a>
+                <img
+                  src="https://shadfinity.sanjaybora.in/favicon.ico"
+                  className="w-4 h-4"
+                />
+              </div>
+            </div>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Added support for custom React components in chatbot messages and options. This allows developers to use any React component within the chatbot's interface.

Changes:
- Updated flowNode type to accept React.ReactNode for messages and options
- Modified Message and SingleChoice components to handle React components
- Added demo implementation with Card and Button components

This should help with issue #3. Let me know if you'd like any changes!